### PR TITLE
Return str version of BSON on deserializer

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ class PyObjectId(ObjectId):
     def validate(cls, v):
         if not ObjectId.is_valid(v):
             raise ValueError("Invalid objectid")
-        return ObjectId(v)
+        return str(v)
 
     @classmethod
     def __modify_schema__(cls, field_schema):


### PR DESCRIPTION
Returning an ObjectId causes 500 error
> ValueError: [TypeError("'ObjectId' object is not iterable"), TypeError('vars() argument must have __dict__ attribute')]