### PR TITLE
fix: remove response body from 204 response in DELETE /id

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 from fastapi import FastAPI, Body, HTTPException, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, EmailStr
 from bson import ObjectId
@@ -118,6 +118,6 @@ async def delete_student(id: str):
     delete_result = await db["students"].delete_one({"_id": id})
 
     if delete_result.deleted_count == 1:
-        return JSONResponse(status_code=status.HTTP_204_NO_CONTENT)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     raise HTTPException(status_code=404, detail=f"Student {id} not found")


### PR DESCRIPTION
To reproduce the problem being solved here: 
1. POST a new user
2. GET its id
3. DELETE /{id}

At this point h11 throws an exception

```text
File "/[...]/mongodb-with-fastapi/venv/lib/python3.8/site-packages/h11/_writers.py", line 98, in send_data
    raise LocalProtocolError("Too much data for declared Content-Length")
h11._util.LocalProtocolError: Too much data for declared Content-Length
```

As explained in [this comment](https://github.com/tiangolo/fastapi/issues/2253#issuecomment-717357627), this is because
204 response should not contain a message body. Quoting the comment:

> HTTP 204 No Content cannot contain a message body: https://tools.ietf.org/html/rfc7230#section-3.3.3
"Any response to a HEAD request and any response with a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status code is always terminated by the first empty line after the header fields, regardless of the header fields present in the message, and thus cannot contain a message body."
> content-length forced in h11 to be equal to 0 (h11._connection.py:75) so when you return something in this endpoints there is exception raised

---

This PR solves this by replacing `JSONResponse` by `Response`.