### PR TITLE
Fix `Object of type ObjectId is not JSON serializable` and queries by ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import os
 from fastapi import FastAPI, Body, HTTPException, status
-from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, EmailStr
 from bson import ObjectId
@@ -68,12 +67,12 @@ class UpdateStudentModel(BaseModel):
         }
 
 
-@app.post("/", response_description="Add new student", response_model=StudentModel)
+@app.post("/", response_description="Add new student", response_model=StudentModel, status_code=status.HTTP_201_CREATED)
 async def create_student(student: StudentModel = Body(...)):
     student = jsonable_encoder(student)
     new_student = await db["students"].insert_one(student)
     created_student = await db["students"].find_one({"_id": new_student.inserted_id})
-    return JSONResponse(status_code=status.HTTP_201_CREATED, content=created_student)
+    return created_student
 
 
 @app.get(
@@ -113,11 +112,11 @@ async def update_student(id: str, student: UpdateStudentModel = Body(...)):
     raise HTTPException(status_code=404, detail=f"Student {id} not found")
 
 
-@app.delete("/{id}", response_description="Delete a student")
+@app.delete("/{id}", response_description="Delete a student", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_student(id: str):
     delete_result = await db["students"].delete_one({"_id": id})
 
     if delete_result.deleted_count == 1:
-        return JSONResponse(status_code=status.HTTP_204_NO_CONTENT)
+        return
 
     raise HTTPException(status_code=404, detail=f"Student {id} not found")

--- a/app.py
+++ b/app.py
@@ -86,19 +86,19 @@ async def list_students():
 @app.get(
     "/{id}", response_description="Get a single student", response_model=StudentModel
 )
-async def show_student(id: str):
-    if (student := await db["students"].find_one({"_id": ObjectId(id)})) is not None:
+async def show_student(id: PyObjectId):
+    if (student := await db["students"].find_one({"_id": id})) is not None:
         return student
 
     raise HTTPException(status_code=404, detail=f"Student {id} not found")
 
 
 @app.put("/{id}", response_description="Update a student", response_model=StudentModel)
-async def update_student(id: str, student: UpdateStudentModel = Body(...)):
+async def update_student(id: PyObjectId, student: UpdateStudentModel = Body(...)):
     student = {k: v for k, v in student.dict().items() if v is not None}
 
     if len(student) >= 1:
-        update_result = await db["students"].update_one({"_id": ObjectId(id)}, {"$set": student})
+        update_result = await db["students"].update_one({"_id": id}, {"$set": student})
 
         if update_result.modified_count == 1:
             if (
@@ -106,15 +106,15 @@ async def update_student(id: str, student: UpdateStudentModel = Body(...)):
             ) is not None:
                 return updated_student
 
-    if (existing_student := await db["students"].find_one({"_id": ObjectId(id)})) is not None:
+    if (existing_student := await db["students"].find_one({"_id": id})) is not None:
         return existing_student
 
     raise HTTPException(status_code=404, detail=f"Student {id} not found")
 
 
 @app.delete("/{id}", response_description="Delete a student", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_student(id: str):
-    delete_result = await db["students"].delete_one({"_id": ObjectId(id)})
+async def delete_student(id: PyObjectId):
+    delete_result = await db["students"].delete_one({"_id": id})
 
     if delete_result.deleted_count == 1:
         return

--- a/app.py
+++ b/app.py
@@ -87,7 +87,7 @@ async def list_students():
     "/{id}", response_description="Get a single student", response_model=StudentModel
 )
 async def show_student(id: str):
-    if (student := await db["students"].find_one({"_id": id})) is not None:
+    if (student := await db["students"].find_one({"_id": ObjectId(id)})) is not None:
         return student
 
     raise HTTPException(status_code=404, detail=f"Student {id} not found")
@@ -98,7 +98,7 @@ async def update_student(id: str, student: UpdateStudentModel = Body(...)):
     student = {k: v for k, v in student.dict().items() if v is not None}
 
     if len(student) >= 1:
-        update_result = await db["students"].update_one({"_id": id}, {"$set": student})
+        update_result = await db["students"].update_one({"_id": ObjectId(id)}, {"$set": student})
 
         if update_result.modified_count == 1:
             if (
@@ -106,7 +106,7 @@ async def update_student(id: str, student: UpdateStudentModel = Body(...)):
             ) is not None:
                 return updated_student
 
-    if (existing_student := await db["students"].find_one({"_id": id})) is not None:
+    if (existing_student := await db["students"].find_one({"_id": ObjectId(id)})) is not None:
         return existing_student
 
     raise HTTPException(status_code=404, detail=f"Student {id} not found")
@@ -114,7 +114,7 @@ async def update_student(id: str, student: UpdateStudentModel = Body(...)):
 
 @app.delete("/{id}", response_description="Delete a student", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_student(id: str):
-    delete_result = await db["students"].delete_one({"_id": id})
+    delete_result = await db["students"].delete_one({"_id": ObjectId(id)})
 
     if delete_result.deleted_count == 1:
         return


### PR DESCRIPTION
I've started from this example app to write a few routes and noticed a few things.

I couldn't use the `create` route has it raised a `TypeError: Object of type ObjectId is not JSON serializable`.

I think this is because `JSONResponse` expects the `ObjectId` to be converted to string first.

As `fastapi` allows us to define a status code in the route decorator directly anyway, I simply moved the status code there and got rid of the `JSONResponse` objects.

Another issue I had was making the routes based on single object IDs work, the database kept on returning nothing even with existing IDs.

It looks like we can't simply give the database a string as an ID, and have to provide an `ObjectId`, so I changed the `id: str` params to `id: PyObjectId`.