### PR TITLE
Migrate to Pymongo Async from Motor

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,8 @@ from pydantic.functional_validators import BeforeValidator
 from typing_extensions import Annotated
 
 from bson import ObjectId
-import motor.motor_asyncio
+import asyncio
+from pymongo import AsyncMongoClient
 from pymongo import ReturnDocument
 
 
@@ -17,7 +18,7 @@ app = FastAPI(
     title="Student Course API",
     summary="A sample application showing how to use FastAPI to add a ReST API to a MongoDB collection.",
 )
-client = motor.motor_asyncio.AsyncIOMotorClient(os.environ["MONGODB_URL"])
+client = AsyncMongoClient(os.environ["MONGODB_URL"])
 db = client.college
 student_collection = db.get_collection("students")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ idna==3.4
     # via
     #   anyio
     #   email-validator
-motor==3.3.1
+pymongo==4.13
     # via -r requirements.in
 pydantic==2.6.3
     # via
@@ -32,8 +32,6 @@ pydantic==2.6.3
     #   fastapi
 pydantic-core==2.16.3
     # via pydantic
-pymongo==4.5.0
-    # via motor
 sniffio==1.3.0
     # via anyio
 starlette==0.36.3


### PR DESCRIPTION
The new MongoDB standard for asynchronous development with Python is the Pymongo Async driver.

https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/

I'm also in the process of moving and updating the tutorial linked on the README, so I can update that once the new tutorial is published: https://github.com/mongodb/docs-pymongo/pull/250